### PR TITLE
Fix qemu-img version in teeth-latest build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ FROM debian:jessie
 # different it will not cache this layer
 ADD . /tmp/ironic-python-agent
 
+# Add 'testing' for qemu-utils
+RUN echo 'APT::Default-Release "jessie";' > /etc/apt/apt.conf.d/10default && \
+    sed -e 's/jessie/testing/g' /etc/apt/sources.list > /etc/apt/sources.list.d/testing.list
+
 # Install requirements: Python for ironic-python-agent, others for putting an
 # image on disk
 RUN apt-get update && \


### PR DESCRIPTION
This is a commit directly to teeth-latest which is bad, but I'm
pulling this change in from upstream to unblock v2 staging build.
Real fix will be to pull this whole repo to IPA Master.